### PR TITLE
Add start script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "start:azure": "func start",
     "docker:build": "docker build -t yatri-weather .",
-    "docker:run": "docker run -p 5173:5173 yatri-weather"
+    "docker:run": "docker run -p 5173:5173 yatri-weather",
+    "start": "vite preview"
   },
   "dependencies": {
     "axios": "^1.6.7",


### PR DESCRIPTION
Add missing 'start' script to `package.json`.

* Add a new script named 'start' to the `scripts` section.
* Set the 'start' script to run `vite preview`.
* Modify the 'docker:run' script to include a comma at the end.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yatricloud/weather-yatri/pull/8?shareId=f8a095d3-1e7c-4c72-9e95-66c4609f7d52).