### PR TITLE
Add Dockerfile to azure-functions/weather-alert directory

### DIFF
--- a/azure-functions/weather-alert/Dockerfile
+++ b/azure-functions/weather-alert/Dockerfile
@@ -1,0 +1,35 @@
+# Use a proper base image
+FROM node:18-alpine AS build
+
+# Set working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies (include devDependencies for build)
+RUN npm install
+
+# Copy the rest of the app
+COPY . .
+
+# Build the Vite project
+RUN npm run build
+
+
+# -------- Production Stage --------
+FROM node:18-alpine AS prod
+
+# Set working directory
+WORKDIR /app
+
+# Copy built files from the build stage
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package.json ./
+
+# Expose Vite's preview server port
+EXPOSE 5173
+
+# Command to run the preview server on port 5173
+CMD ["npm", "run", "preview", "--", "--port", "5173", "--host"]


### PR DESCRIPTION
Add `Dockerfile` to `azure-functions/weather-alert` directory.

* Copy the contents of the `Dockerfile` from the root directory to the `azure-functions/weather-alert` directory.
* Ensure the `Dockerfile` is in the `azure-functions/weather-alert` directory.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yatricloud/weather-yatri/pull/17?shareId=76530cd8-74ad-470f-a1c9-f439d4d7cd61).