### PR TITLE
Fix build permission error in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN npm install
 # Copy the rest of the app
 COPY . .
 
+# Fix permission error for vite
+RUN chmod +x node_modules/.bin/vite
+
 # Build the Vite project
 RUN npm run build
 

--- a/azure-functions/weather-alert/Dockerfile
+++ b/azure-functions/weather-alert/Dockerfile
@@ -13,6 +13,9 @@ RUN npm install
 # Copy the rest of the app
 COPY . .
 
+# Fix permission error for vite
+RUN chmod +x node_modules/.bin/vite
+
 # Build the Vite project
 RUN npm run build
 


### PR DESCRIPTION
Fix permission error for vite during the build stage in Dockerfiles.

* Add `RUN chmod +x node_modules/.bin/vite` before `RUN npm run build` in `azure-functions/weather-alert/Dockerfile`.
* Add `RUN chmod +x node_modules/.bin/vite` before `RUN npm run build` in `Dockerfile`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yatricloud/weather-yatri/pull/19?shareId=470362cd-2895-407b-aaf4-8f90b4cf0ea0).